### PR TITLE
Add constructor with name parameter

### DIFF
--- a/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLDate.java
+++ b/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLDate.java
@@ -29,8 +29,14 @@ import java.util.Date;
  */
 public class GraphQLDate extends GraphQLScalarType {
 
+    private static final String DEFAULT_NAME = "Date";
+
     public GraphQLDate() {
-        super("Date", "Date type", new Coercing<Date, String>() {
+        this(DEFAULT_NAME);
+    }
+
+    public GraphQLDate(final String name) {
+        super(name, "Date type", new Coercing<Date, String>() {
             private Date convertImpl(Object input) {
                 if (input instanceof String) {
                     LocalDateTime localDateTime = DateTimeHelper.parseDate((String) input);

--- a/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalDate.java
+++ b/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalDate.java
@@ -29,8 +29,14 @@ import java.time.LocalDateTime;
  */
 public class GraphQLLocalDate extends GraphQLScalarType {
 
+    private static final String DEFAULT_NAME = "LocalDate";
+
     public GraphQLLocalDate() {
-        super("LocalDate", "Local Date type", new Coercing<LocalDate, String>() {
+        this(DEFAULT_NAME);
+    }
+
+    public GraphQLLocalDate(final String name) {
+        super(name, "Local Date type", new Coercing<LocalDate, String>() {
             private LocalDate convertImpl(Object input) {
                 if (input instanceof String) {
                     LocalDateTime localDateTime = DateTimeHelper.parseDate((String) input);

--- a/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalDateTime.java
+++ b/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalDateTime.java
@@ -28,8 +28,14 @@ import java.time.LocalDateTime;
  */
 public class GraphQLLocalDateTime extends GraphQLScalarType {
 
+    private static final String DEFAULT_NAME = "LocalDateTime";
+
     public GraphQLLocalDateTime() {
-        super("LocalDateTime", "Local Date Time type", new Coercing<LocalDateTime, String>() {
+        this(DEFAULT_NAME);
+    }
+
+    public GraphQLLocalDateTime(final String name) {
+        super(name, "Local Date Time type", new Coercing<LocalDateTime, String>() {
             private LocalDateTime convertImpl(Object input) {
                 if (input instanceof String) {
                     LocalDateTime localDateTime = DateTimeHelper.parseDate((String) input);

--- a/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalTime.java
+++ b/graphql-java-datetime/src/main/java/com/zhokhov/graphql/datetime/GraphQLLocalTime.java
@@ -31,10 +31,16 @@ import java.time.format.DateTimeParseException;
  */
 public class GraphQLLocalTime extends GraphQLScalarType {
 
+    private static final String DEFAULT_NAME = "LocalTime";
+
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME.withZone(ZoneOffset.UTC);
 
     public GraphQLLocalTime() {
-        super("LocalTime", "Local Time type", new Coercing<LocalTime, String>() {
+        this(DEFAULT_NAME);
+    }
+
+    public GraphQLLocalTime(final String name) {
+        super(name, "Local Time type", new Coercing<LocalTime, String>() {
             private LocalTime convertImpl(Object input) {
                 if (input instanceof String) {
                     try {


### PR DESCRIPTION
The goal is to allow users to name the scalars however they like/need in their schemas.

Let's say someone is starting a new project with a schema that is already used by other applications: by forcing the Java classes names to be used in the schema, we are forcing all other projects that use the same schema to depend on the Java classes names. 

By adding this new constructor, someone who wants to use the new Java 8 time API and wants to keep the `scalar Date` in their schema, for example, would be able to simply import this project as a dependency to their project. I had this necessity today while developing a new service, so I had to hard code the `GraphQLLocalDate` class to my project replacing the name with `"Date"`.

**Note:**
 - I believe a builder pattern would fit much better this scenario and I'd be willing to change my PR, if we agree this is the best option.