### PR TITLE
updating versions for compatibility with graphql-spring-boot-starter 6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,10 +24,10 @@ org.gradle.jvmargs=-Dsun.jnu.encoding=UTF-8 -Djavax.servlet.request.encoding=UTF
 # Libraries
 
 kotlin.version=1.3.11
-graphqlJavaVersion=11.0
-graphqlJavaServletVersion=7.3.2
-graphqlSpringBootVersion=5.6.1
-graphqlJavaToolsVersion=5.5.1
+graphqlJavaVersion=13.0
+graphqlJavaServletVersion=9.0.0
+graphqlSpringBootVersion=6.0.0
+graphqlJavaToolsVersion=5.7.1
 springBootVersion=2.1.3.RELEASE
 groovyVersion=2.5.5
 spockVersion=1.2-groovy-2.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ spockVersion=1.2-groovy-2.5
 
 # Project
 
-projectVersion=1.5.1
+projectVersion=1.6.0
 projectName=graphql-java-datetime
 projectDescription=The set of RFC 3339 compliant date/time scalar types for GraphQL Java implementation
 projectGitRepoUrl=https://github.com/donbeave/graphql-java-datetime

--- a/graphql-datetime-autoconfigure/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeAutoConfiguration.java
+++ b/graphql-datetime-autoconfigure/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeAutoConfiguration.java
@@ -15,7 +15,6 @@
  */
 package com.zhokhov.graphql.datetime.boot;
 
-import com.oembedler.moon.graphql.boot.GraphQLJavaToolsAutoConfiguration;
 import com.zhokhov.graphql.datetime.GraphQLDate;
 import com.zhokhov.graphql.datetime.GraphQLLocalDate;
 import com.zhokhov.graphql.datetime.GraphQLLocalDateTime;
@@ -27,11 +26,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import graphql.kickstart.tools.boot.GraphQLJavaToolsAutoConfiguration;
+
 /**
  * @author <a href='mailto:alexey@zhokhov.com'>Alexey Zhokhov</a>
  */
 @Configuration
-@AutoConfigureBefore({GraphQLJavaToolsAutoConfiguration.class})
+@AutoConfigureBefore({ GraphQLJavaToolsAutoConfiguration.class})
 @EnableConfigurationProperties(GraphQLDateTimeProperties.class)
 public class GraphQLDateTimeAutoConfiguration {
 

--- a/graphql-datetime-autoconfigure/src/test/java/com/zhokhov/graphql/datetime/boot/test/ContextHelper.java
+++ b/graphql-datetime-autoconfigure/src/test/java/com/zhokhov/graphql/datetime/boot/test/ContextHelper.java
@@ -18,7 +18,6 @@ package com.zhokhov.graphql.datetime.boot.test;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.oembedler.moon.graphql.boot.GraphQLJavaToolsAutoConfiguration;
 import com.zhokhov.graphql.datetime.GraphQLDate;
 import com.zhokhov.graphql.datetime.GraphQLLocalDate;
 import com.zhokhov.graphql.datetime.GraphQLLocalDateTime;
@@ -31,6 +30,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.AbstractApplicationContext;
+
+import graphql.kickstart.tools.boot.GraphQLJavaToolsAutoConfiguration;
 
 /**
  * @author <a href='mailto:alexey@zhokhov.com'>Alexey Zhokhov</a>


### PR DESCRIPTION
The package of `GraphQLJavaToolsAutoConfiguration.java` was changed in the new version, so I updated the dependencies and fixed the imports.