### PR TITLE
Use openjdk8 instead of oraclejdk8 in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 services:
     - docker
 jdk:
-    - oraclejdk8
+    - openjdk8
 before_cache:
     - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
     - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
Not sure if this fixes the build yet, looking to test