### PR TITLE
Duration scalar - fix for defining custom scalar name 

### DIFF
--- a/graphql-datetime-autoconfigure-common/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeAutoConfiguration.java
+++ b/graphql-datetime-autoconfigure-common/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeAutoConfiguration.java
@@ -106,7 +106,7 @@ public class GraphQLDateTimeAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public GraphQLDuration graphQLDuration(GraphQLDateTimeProperties configurationProperties) {
-        final String name = configurationProperties.getOffsetDateTime().getScalarName();
+        final String name = configurationProperties.getDuration().getScalarName();
         if (name == null) {
             return new GraphQLDuration();
         } else {

--- a/graphql-datetime-autoconfigure-common/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeProperties.java
+++ b/graphql-datetime-autoconfigure-common/src/main/java/com/zhokhov/graphql/datetime/boot/GraphQLDateTimeProperties.java
@@ -14,6 +14,7 @@ public class GraphQLDateTimeProperties {
     private ScalarDefinition localTime = new ScalarDefinition();
     private ScalarDefinition offsetDateTime = new ScalarDefinition();
     private ScalarDefinition yearMonth = new ScalarDefinition();
+    private ScalarDefinition duration = new ScalarDefinition();
     private boolean zoneConversionEnabled = false;
 
     ScalarDefinition getDate() {
@@ -38,6 +39,10 @@ public class GraphQLDateTimeProperties {
 
     ScalarDefinition getYearMonth() {
         return yearMonth;
+    }
+
+    ScalarDefinition getDuration() {
+        return duration;
     }
 
     public static class ScalarDefinition {
@@ -86,6 +91,10 @@ public class GraphQLDateTimeProperties {
 
     public void setYearMonth(ScalarDefinition yearMonth) {
         this.yearMonth = yearMonth;
+    }
+
+    public void setDuration(ScalarDefinition duration) {
+        this.duration = duration;
     }
 
     public boolean isZoneConversionEnabled() {


### PR DESCRIPTION
Fixing Duration scalar so that you can define a custom scalar name.

Current behavior impacts Duration scalar and also OffsetDateTime scalar

#30 