### PR TITLE
Updating springboot and kotlin versions to match graphql-java-tools:11.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,10 @@ org.gradle.jvmargs=-Dsun.jnu.encoding=UTF-8 -Djavax.servlet.request.encoding=UTF
 
 # Libraries
 
-kotlin.version=1.3.72
+kotlin.version=1.4.10
 graphqlJavaVersion=16.1
-graphqlSpringBootVersion=11.0.0
-springBootVersion=2.3.6.RELEASE
+graphqlSpringBootVersion=11.1.0
+springBootVersion=2.4.2
 groovyVersion=2.5.12
 spockVersion=1.3-groovy-2.5
 

--- a/graphql-datetime-sample-app-webflux/build.gradle
+++ b/graphql-datetime-sample-app-webflux/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux:$springBootVersion")
     implementation("com.graphql-java-kickstart:graphql-kickstart-spring-boot-starter-webflux:$graphqlSpringBootVersion")
     implementation("com.graphql-java-kickstart:graphql-kickstart-spring-boot-starter-tools:$graphqlSpringBootVersion")
-    implementation("io.projectreactor:reactor-core:3.3.6.RELEASE")
+    implementation("io.projectreactor:reactor-core:3.4.2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }


### PR DESCRIPTION
Dependent on https://github.com/graphql-java-kickstart/graphql-java-tools/pull/473 